### PR TITLE
default to Inf

### DIFF
--- a/src/Bonobo.jl
+++ b/src/Bonobo.jl
@@ -175,8 +175,8 @@ function initialize(;
     sense = :Min,
 )
     return BnBTree{Node,typeof(root),Value,Solution}(
-        NaN, 
-        NaN,
+        Inf,
+        -Inf,
         Vector{Solution}(),
         PriorityQueue{Int,Node}(),
         root,


### PR DESCRIPTION
The default incumbent and lb should be set to + and - Inf respectively which make more sense as trivial values than NaN which require an additional check.

Otherwise
```
tree.incumbent >= val
```
is always false on the first iteration