### PR TITLE
cb -> callback + docstring

### DIFF
--- a/src/Bonobo.jl
+++ b/src/Bonobo.jl
@@ -222,7 +222,8 @@ branch!(tree, node)
 
 A `callback` function can be provided which will be called whenever a node is closed.
 It always has the arguments `tree` and `node` and is called after the `node` is closed. 
-In two cases an additional keyword argument (`kwarg`) is added:
+Additionally the callback function **must** accept additional keyword arguments (`kwargs`) 
+which are set in the following ways:
 1. If the node is infeasible the kwarg `node_infeasible` is set to `true`.
 2. If the node has a higher lower bound than the incumbent the kwarg `worse_than_incumbent` is set to `true`.
 """

--- a/test/end2end/mip.jl
+++ b/test/end2end/mip.jl
@@ -186,6 +186,6 @@ end
         status = MOI.OPTIMIZE_NOT_CALLED
     ))
 
-    BB.optimize!(bnb_model; cb=callback_test)
+    BB.optimize!(bnb_model; callback=callback_test)
     @test nr_callback_checks_successful > 0
 end


### PR DESCRIPTION
Fixes #22

I've changed the argument `cb` to `callback` and added some information of when it is called and with which arguments. 
Regarding the question in the issue itself: It is currently only expected to use it for logging and debugging purposes.
As it is called `callback` and not `callback!` the `tree` and `node` argument shouldn't be changed by the user. 