### PR TITLE
bugfix worse lower bound than incumbent

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,8 +1,11 @@
 # Changelog
 
+## Unreleased
+- Bugfix: It was possible to add a node with a worse lower bound than the best incumbent
+
 ## v0.1.1
 - Branching and traversing strategies take values not types
-- Bugfix: It was possible to add a node with a worse lower bound than the best incumbent
+
 
 ## v0.1.0
 - BFS traverse strategy

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,7 @@
 
 ## v0.1.1
 - Branching and traversing strategies take values not types
+- Bugfix: It was possible to add a node with a worse lower bound than the best incumbent
 
 ## v0.1.0
 - BFS traverse strategy

--- a/src/Bonobo.jl
+++ b/src/Bonobo.jl
@@ -254,18 +254,18 @@ function optimize!(tree::BnBTree; callback=(args...; kwargs...)->())
         end
 
         set_node_bound!(tree.sense, node, lb, ub)
-        tree.node_queue[node.id] = (node.lb, node.id)
-        _ , prio = peek(tree.node_queue)
-        @assert tree.lb <= prio[1]
-        tree.lb = prio[1]
-
-
+       
         # if the evaluated lower bound is worse than the best incumbent -> close and continue
         if node.lb >= tree.incumbent
             close_node!(tree, node)
             callback(tree, node; worse_than_incumbent=true)
             continue
         end
+
+        tree.node_queue[node.id] = (node.lb, node.id)
+        _ , prio = peek(tree.node_queue)
+        @assert tree.lb <= prio[1]
+        tree.lb = prio[1]
 
         updated = update_best_solution!(tree, node)
         if updated 

--- a/src/node.jl
+++ b/src/node.jl
@@ -37,9 +37,12 @@ Add a new node to the tree using the `node_info`. For information on that see [`
 function add_node!(tree::BnBTree{Node}, parent::Union{AbstractNode, Nothing}, node_info::NamedTuple) where Node <: AbstractNode
     node_id = tree.num_nodes + 1
     node = create_node(Node, node_id, parent, node_info)
-    tree.nodes[node_id] = node
-    tree.node_queue[node_id] = (node.lb, node_id)
-    tree.num_nodes += 1
+    # only add the node if it's better than the current best solution
+    if node.lb < tree.incumbent
+        tree.nodes[node_id] = node
+        tree.node_queue[node_id] = (node.lb, node_id)
+        tree.num_nodes += 1
+    end
 end
 
 """


### PR DESCRIPTION
Only add a new solution if it can produce better results than the current incumbent.
Also if the lower bound is worse after evaluating the node we don't want to falsely update the lower bound such that it looks like the lower bound is worse than the incumbent