### PR TITLE
add node directly with default empty BnBNodeInfo

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased and breaking
+- Removed NamedTupleTools add node directly
+
 ## Unreleased
 - Store all solutions
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,9 @@ version = "0.1.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 
 [compat]
 DataStructures = "0.18"
-NamedTupleTools = "0.13, 0.14"
 julia = "1.6"
 
 [extras]

--- a/src/Bonobo.jl
+++ b/src/Bonobo.jl
@@ -1,7 +1,6 @@
 module Bonobo
 
 using DataStructures
-using NamedTupleTools
 
 """
     AbstractNode
@@ -37,6 +36,8 @@ mutable struct BnBNodeInfo
     ub :: Float64
 end
 
+BnBNodeInfo() = BnBNodeInfo(-1, NaN, NaN)
+
 """
     DefaultNode <: AbstractNode
 
@@ -45,6 +46,10 @@ Currently this includes only the necessary `std::BnBNodeInfo` which needs to be 
 """
 mutable struct DefaultNode <: AbstractNode
     std :: BnBNodeInfo
+end
+
+function (::Type{AN})(args...) where AN
+    AN(BnBNodeInfo(), args...)
 end
 
 """

--- a/src/node.jl
+++ b/src/node.jl
@@ -25,38 +25,37 @@ Bonobo.set_root!(tree, (
 ))
 ```
 """
-function set_root!(tree::BnBTree, node_info::NamedTuple)
-    add_node!(tree, nothing, node_info)
+function set_root!(tree::BnBTree, node::AbstractNode)
+    add_node!(tree, nothing, node)
 end
 
 """
-    add_node!(tree::BnBTree{Node}, parent::Union{AbstractNode, Nothing}, node_info::NamedTuple)
+    add_node!(tree::BnBTree{Node}, parent::Union{Node, Nothing}, node::Node) where Node <: AbstractNode
 
-Add a new node to the tree using the `node_info`. For information on that see [`set_root!`](@ref).
+Add a new node to the tree using the `node`. For information on that see [`set_root!`](@ref).
 """
-function add_node!(tree::BnBTree{Node}, parent::Union{AbstractNode, Nothing}, node_info::NamedTuple) where Node <: AbstractNode
+function add_node!(tree::BnBTree{Node}, parent::Union{Node, Nothing}, node::Node) where Node <: AbstractNode
     node_id = tree.num_nodes + 1
-    node = create_node(Node, node_id, parent, node_info)
+    node = create_node(Node, node_id, parent, node)
     tree.nodes[node_id] = node
     tree.node_queue[node_id] = (node.lb, node_id)
     tree.num_nodes += 1
 end
 
 """
-    create_node(Node, node_id::Int, parent::Union{AbstractNode, Nothing}, node_info::NamedTuple)
+    create_node(Node, node_id::Int, parent::Union{AbstractNode, Nothing}, node::AbstractNode)
 
-Creates a node of type `Node` with id `node_id` and the named tuple `node_info`. 
+Creates a node of type `Node` with id `node_id` and the named tuple `node`. 
 For information on that see [`set_root!`](@ref).
 """
-function create_node(Node, node_id::Int, parent::Union{AbstractNode, Nothing}, node_info::NamedTuple)
+function create_node(Node, node_id::Int, parent::Union{AbstractNode, Nothing}, node::AbstractNode)
     lb = -Inf
     if !isnothing(parent)
         lb = parent.lb
     end
-    bnb_node = structfromnt(BnBNodeInfo, (id = node_id, lb = lb, ub = Inf))
-    bnb_nt = (std = bnb_node,)
-    node_nt = merge(bnb_nt, node_info)
-    return structfromnt(Node, node_nt)
+    bnb_node = BnBNodeInfo(node_id, lb, Inf)
+    node.std = bnb_node 
+    return node
 end
 
 """

--- a/test/end2end/dummy.jl
+++ b/test/end2end/dummy.jl
@@ -17,10 +17,7 @@ function BB.get_relaxed_values(::BnBTree{BB.DefaultNode, DummyRoot}, node::BB.De
 end
 
 function BB.get_branching_nodes_info(tree::BnBTree{BB.DefaultNode, DummyRoot}, node::BB.DefaultNode, vidx::Int)
-    node_info = NamedTuple[]
-    push!(node_info, NamedTuple())
-    push!(node_info, NamedTuple())
-    return node_info
+    return [BB.DefaultNode(), BB.DefaultNode()]
 end
 
 function dummy_callback(tree, node; node_infeasible=false, worse_than_incumbent=false)
@@ -38,7 +35,7 @@ end
         sense = :Min
     )
    
-    BB.set_root!(bnb_model, NamedTuple())
+    BB.set_root!(bnb_model, BB.DefaultNode())
 
     BB.optimize!(bnb_model; callback=dummy_callback)
 

--- a/test/end2end/mip.jl
+++ b/test/end2end/mip.jl
@@ -56,7 +56,7 @@ end
 
 function BB.get_branching_nodes_info(tree::BnBTree{MIPNode, JuMP.Model}, node::MIPNode, vidx::Int)
     m = tree.root
-    node_info = NamedTuple[]
+    branches = MIPNode[]
 
     var = VariableRef(m, MOI.VariableIndex(vidx))
 
@@ -69,21 +69,21 @@ function BB.get_branching_nodes_info(tree::BnBTree{MIPNode, JuMP.Model}, node::M
     # left child set upper bound
     ubs[vidx] = floor(Int, val)
 
-    push!(node_info, (
-        lbs = copy(node.lbs),
-        ubs = ubs,
-        status = MOI.OPTIMIZE_NOT_CALLED,
+    push!(branches, MIPNode(
+        copy(node.lbs),
+        ubs,
+        MOI.OPTIMIZE_NOT_CALLED,
     ))
 
     # right child set lower bound
     lbs[vidx] = ceil(Int, val)
 
-    push!(node_info, (
-        lbs = lbs,
-        ubs = copy(node.ubs),
-        status = MOI.OPTIMIZE_NOT_CALLED,
+    push!(branches, MIPNode(
+        lbs,
+        copy(node.ubs),
+        MOI.OPTIMIZE_NOT_CALLED,
     ))
-    return node_info
+    return branches
 end
 
 @testset "MIP Problem with 3 variables" begin
@@ -101,10 +101,10 @@ end
         root = m,
         sense = objective_sense(m) == MOI.MAX_SENSE ? :Max : :Min
     )
-    BB.set_root!(bnb_model, (
-        lbs = zeros(length(x)),
-        ubs = fill(Inf, length(x)),
-        status = MOI.OPTIMIZE_NOT_CALLED
+    BB.set_root!(bnb_model, MIPNode(
+        zeros(length(x)),
+        fill(Inf, length(x)),
+        MOI.OPTIMIZE_NOT_CALLED
     ))
 
     BB.optimize!(bnb_model)
@@ -130,10 +130,10 @@ end
         root = m,
         sense = objective_sense(m) == MOI.MAX_SENSE ? :Max : :Min
     )
-    BB.set_root!(bnb_model, (
-        lbs = zeros(length(x)),
-        ubs = fill(Inf, length(x)),
-        status = MOI.OPTIMIZE_NOT_CALLED
+    BB.set_root!(bnb_model, MIPNode(
+        zeros(length(x)),
+        fill(Inf, length(x)),
+        MOI.OPTIMIZE_NOT_CALLED
     ))
 
     BB.optimize!(bnb_model)

--- a/test/unit/add_node.jl
+++ b/test/unit/add_node.jl
@@ -17,13 +17,13 @@ struct TestRoot end
         root = TestRoot(),
         sense = :Min
     )
-    BB.set_root!(bnb_model, NamedTuple())
+    BB.set_root!(bnb_model, BB.DefaultNode())
     root = BB.get_next_node(bnb_model, BB.BFS())
     lb, ub = BB.evaluate_node!(bnb_model, root)
     BB.set_node_bound!(bnb_model.sense, root, lb, ub)
 
     # adding a new node with the root as parent
-    BB.add_node!(bnb_model, root, NamedTuple())
+    BB.add_node!(bnb_model, root, BB.DefaultNode())
     last_node_id = bnb_model.num_nodes
     @test bnb_model.nodes[last_node_id].lb == 0.0
 end


### PR DESCRIPTION
Implements #37 

I'm not sure whether this approach is a reasonable one. There is a default `BnBNodeInfo` now which is used by a default constructor of an AbstractNode. The values of id, lb and ub are then updated when the node is actually added to the tree.

All docstrings need fixes but maybe you (@matbesancon ) can already say whether this solves the flexibility problem you had in mind.